### PR TITLE
Push uri as Xcom

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -575,7 +575,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         logger.info("Outlets: %s", outlets)
         self.register_dataset(inlets, outlets, context)
 
-        if settings.enable_uri_xcom and outlets and (uris := [outlet.uri for outlet in outlets]):
+        if settings.enable_uri_xcom and (uris := [outlet.uri for outlet in outlets]):
             context["ti"].xcom_push(key="uri", value=uris)
             logger.info(f"Pushed outlet URI(s) to XCom: {uris}")
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -575,6 +575,11 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         logger.info("Outlets: %s", outlets)
         self.register_dataset(inlets, outlets, context)
 
+        if settings.enable_uri_xcom and outlets:
+            uris = [outlet.uri for outlet in outlets]
+            context["ti"].xcom_push(key="uri", value=uris)
+            logger.info("Pushed outlet URIs to XCom: %s", uris)
+
     def _update_partial_parse_cache(self, tmp_dir_path: Path) -> None:
         if self.cache_dir is None:
             return

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -575,10 +575,9 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         logger.info("Outlets: %s", outlets)
         self.register_dataset(inlets, outlets, context)
 
-        if settings.enable_uri_xcom and outlets:
-            uris = [outlet.uri for outlet in outlets]
+        if settings.enable_uri_xcom and outlets and (uris := [outlet.uri for outlet in outlets]):
             context["ti"].xcom_push(key="uri", value=uris)
-            logger.info("Pushed outlet URIs to XCom: %s", uris)
+            logger.info(f"Pushed outlet URI(s) to XCom: {uris}")
 
     def _update_partial_parse_cache(self, tmp_dir_path: Path) -> None:
         if self.cache_dir is None:

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -19,7 +19,7 @@ DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
 enable_cache = conf.getboolean("cosmos", "enable_cache", fallback=True)
 enable_dataset_alias = conf.getboolean("cosmos", "enable_dataset_alias", fallback=True)
-enable_uri_xcom = conf.getboolean("cosmos", "enable_uri_xcom", fallback=True) # put False later
+enable_uri_xcom = conf.getboolean("cosmos", "enable_uri_xcom", fallback=False)
 use_dataset_airflow3_uri_standard = conf.getboolean(
     "cosmos",
     "enable_dataset_airflow3_uri",

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -19,6 +19,7 @@ DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
 enable_cache = conf.getboolean("cosmos", "enable_cache", fallback=True)
 enable_dataset_alias = conf.getboolean("cosmos", "enable_dataset_alias", fallback=True)
+enable_uri_xcom = conf.getboolean("cosmos", "enable_uri_xcom", fallback=True) # put False later
 use_dataset_airflow3_uri_standard = conf.getboolean(
     "cosmos",
     "enable_dataset_airflow3_uri",

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -203,3 +203,44 @@ they can set this configuration to ``False``. It can also be set in the ``airflo
     enable_dataset_alias = False
 
 Starting in Airflow 3, Cosmos users no longer allowed to set ``AIRFLOW__COSMOS__ENABLE_DATASET_ALIAS`` to ``True``.
+
+
+Emitting Dataset URIs as XCom
+.............................
+
+By default, Cosmos emits datasets as Airflow inlets/outlets but does not expose the raw dataset URIs as XCom values.
+If you need access to the dataset URIs (for example, to use them in downstream tasks or for debugging purposes),
+you can enable the ``enable_uri_xcom`` setting.
+
+When enabled, Cosmos will push the outlet URIs to XCom with the key ``uri`` after each task execution that emits datasets.
+
+To enable this feature, set the environment variable:
+
+.. code-block:: bash
+
+    export AIRFLOW__COSMOS__ENABLE_URI_XCOM=True
+
+Or in your ``airflow.cfg``:
+
+.. code-block::
+
+    [cosmos]
+    enable_uri_xcom = True
+
+When enabled, you can access the URIs in downstream tasks using XCom:
+
+.. code-block:: python
+
+    from airflow.decorators import task
+
+    @task
+    def process_uris(**context):
+        ti = context["ti"]
+        uris = ti.xcom_pull(task_ids="my_dbt_task", key="uri")
+        for uri in uris:
+            print(f"Processing dataset: {uri}")
+
+.. note::
+
+    This feature is available for all Airflow versions (2.4+) and works alongside the existing dataset emission behavior.
+    The ``uri`` XCom contains a list of URI strings, even if there is only one outlet.


### PR DESCRIPTION
This pull request introduces a new feature to optionally emit dataset URIs as XCom values in Cosmos, along with comprehensive documentation and tests. The feature is controlled by a new configuration setting and is designed to help users access dataset URIs in downstream Airflow tasks when needed.

The most important changes are:

**Feature: Emit Dataset URIs as XCom**

* Added a new setting, `enable_uri_xcom`, to `cosmos/settings.py` to control whether dataset URIs are pushed to XCom after task execution.
* Updated the `_handle_datasets` method in `cosmos/operators/local.py` to push outlet URIs to XCom with the key `"uri"` when `enable_uri_xcom` is enabled and outlets are present.

**Documentation**

* Added a section to `docs/configuration/scheduling.rst` explaining the new `enable_uri_xcom` feature, how to enable it, and how to access the emitted URIs in downstream tasks.

**Testing**

* Added multiple tests to `tests/operators/test_local.py` to verify that URIs are pushed to XCom only when the feature is enabled, and to check correct behavior for single, multiple, and missing outlets.