### PR TITLE
Add experimental orjson parser for faster JSON processing

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -18,11 +18,10 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.models import Variable
 
-# Optional orjson import for faster JSON parsing
 try:
     import orjson
 except ImportError:
-    orjson = None  # type: ignore
+    orjson = None
 
 if TYPE_CHECKING:
     try:
@@ -1132,7 +1131,6 @@ class DbtGraph:
         if TYPE_CHECKING:
             assert self.project.manifest_path is not None  # pragma: no cover
 
-        # Load manifest using orjson if enabled, otherwise use standard json
         if settings.enable_orjson_parser:
             if orjson is None:
                 raise CosmosLoadDbtException(

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -18,6 +18,12 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.models import Variable
 
+# Optional orjson import for faster JSON parsing
+try:
+    import orjson
+except ImportError:
+    orjson = None  # type: ignore
+
 if TYPE_CHECKING:
     try:
         # Airflow 3 onwards
@@ -1126,67 +1132,76 @@ class DbtGraph:
         if TYPE_CHECKING:
             assert self.project.manifest_path is not None  # pragma: no cover
 
-        with self.project.manifest_path.open() as fp:
-            manifest = json.load(fp)
+        # Load manifest using orjson if enabled, otherwise use standard json
+        if settings.enable_orjson_parser:
+            if orjson is None:
+                raise CosmosLoadDbtException(
+                    "orjson is not installed. Install it with: pip install 'astronomer-cosmos[orjson]'"
+                )
+            manifest_content = self.project.manifest_path.read_bytes()
+            manifest = orjson.loads(manifest_content)
+        else:
+            with self.project.manifest_path.open() as fp:
+                manifest = json.load(fp)
 
-            resources = {**manifest.get("nodes", {}), **manifest.get("sources", {}), **manifest.get("exposures", {})}
-            for unique_id, node_dict in resources.items():
-                # External nodes (e.g., from dbt-loom) may not have a file path - skip them
-                # Check for both None and empty string since dbt-loom may set either
-                original_file_path = node_dict.get("original_file_path")
-                if not original_file_path:
-                    logger.debug(
-                        "Skipping node `%s` because it has no file path (likely an external reference from dbt-loom or similar)",
-                        unique_id,
-                    )
-                    continue
+        resources = {**manifest.get("nodes", {}), **manifest.get("sources", {}), **manifest.get("exposures", {})}
+        for unique_id, node_dict in resources.items():
+            # External nodes (e.g., from dbt-loom) may not have a file path - skip them
+            # Check for both None and empty string since dbt-loom may set either
+            original_file_path = node_dict.get("original_file_path")
+            if not original_file_path:
+                logger.debug(
+                    "Skipping node `%s` because it has no file path (likely an external reference from dbt-loom or similar)",
+                    unique_id,
+                )
+                continue
 
-                node = DbtNode(
-                    unique_id=unique_id,
-                    package_name=node_dict.get("package_name"),
-                    resource_type=DbtResourceType(node_dict["resource_type"]),
-                    depends_on=node_dict.get("depends_on", {}).get("nodes", []),
-                    file_path=self.execution_config.project_path / _normalize_path(original_file_path),
-                    tags=node_dict.get("tags") or [],
-                    config=node_dict.get("config") or {},
-                    has_freshness=(
-                        is_freshness_effective(node_dict.get("freshness"))
-                        if DbtResourceType(node_dict["resource_type"]) == DbtResourceType.SOURCE
-                        else False
-                    ),
+            node = DbtNode(
+                unique_id=unique_id,
+                package_name=node_dict.get("package_name"),
+                resource_type=DbtResourceType(node_dict["resource_type"]),
+                depends_on=node_dict.get("depends_on", {}).get("nodes", []),
+                file_path=self.execution_config.project_path / _normalize_path(original_file_path),
+                tags=node_dict.get("tags") or [],
+                config=node_dict.get("config") or {},
+                has_freshness=(
+                    is_freshness_effective(node_dict.get("freshness"))
+                    if DbtResourceType(node_dict["resource_type"]) == DbtResourceType.SOURCE
+                    else False
+                ),
+            )
+
+            nodes[node.unique_id] = node
+
+        if self.render_config.selector:
+            selector_definitions = manifest.get("selectors", {})
+
+            if not selector_definitions:
+                raise CosmosLoadDbtException(f"Selectors not found in manifest file `{self.project.manifest_path}`")
+
+            yaml_selectors = self.load_parsed_selectors(selector_definitions)
+            selections = yaml_selectors.get_parsed(self.render_config.selector)
+
+            if not selections:
+                raise CosmosLoadDbtException(
+                    f"Selector `{self.render_config.selector}` not found in parsed YAML selectors `{selector_definitions}`"
                 )
 
-                nodes[node.unique_id] = node
-
-            if self.render_config.selector:
-                selector_definitions = manifest.get("selectors", {})
-
-                if not selector_definitions:
-                    raise CosmosLoadDbtException(f"Selectors not found in manifest file `{self.project.manifest_path}`")
-
-                yaml_selectors = self.load_parsed_selectors(selector_definitions)
-                selections = yaml_selectors.get_parsed(self.render_config.selector)
-
-                if not selections:
-                    raise CosmosLoadDbtException(
-                        f"Selector `{self.render_config.selector}` not found in parsed YAML selectors `{selector_definitions}`"
-                    )
-
-                self.nodes = nodes
-                self.filtered_nodes = select_nodes(
-                    project_dir=self.execution_config.project_path,
-                    nodes=nodes,
-                    select=selections["select"],
-                    exclude=selections["exclude"],
-                )
-            else:
-                self.nodes = nodes
-                self.filtered_nodes = select_nodes(
-                    project_dir=self.execution_config.project_path,
-                    nodes=nodes,
-                    select=self.render_config.select,
-                    exclude=self.render_config.exclude,
-                )
+            self.nodes = nodes
+            self.filtered_nodes = select_nodes(
+                project_dir=self.execution_config.project_path,
+                nodes=nodes,
+                select=selections["select"],
+                exclude=selections["exclude"],
+            )
+        else:
+            self.nodes = nodes
+            self.filtered_nodes = select_nodes(
+                project_dir=self.execution_config.project_path,
+                nodes=nodes,
+                select=self.render_config.select,
+                exclude=self.render_config.exclude,
+            )
 
     def update_node_dependency(self) -> None:
         """

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -89,3 +89,6 @@ def convert_to_boolean(value: str | None) -> bool:
 enable_telemetry = conf.getboolean("cosmos", "enable_telemetry", fallback=True)
 do_not_track = convert_to_boolean(os.getenv("DO_NOT_TRACK"))
 no_analytics = convert_to_boolean(os.getenv("SCARF_NO_ANALYTICS"))
+
+# EXPERIMENTAL: orjson parser for faster JSON parsing
+enable_orjson_parser = conf.getboolean("cosmos", "enable_orjson_parser", fallback=False)

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -90,5 +90,5 @@ enable_telemetry = conf.getboolean("cosmos", "enable_telemetry", fallback=True)
 do_not_track = convert_to_boolean(os.getenv("DO_NOT_TRACK"))
 no_analytics = convert_to_boolean(os.getenv("SCARF_NO_ANALYTICS"))
 
-# EXPERIMENTAL: orjson parser for faster JSON parsing
+# ORJSON parser for faster JSON deserialization
 enable_orjson_parser = conf.getboolean("cosmos", "enable_orjson_parser", fallback=False)

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -264,7 +264,7 @@ This page lists all available Airflow configurations that affect ``astronomer-co
 .. _enable_orjson_parser:
 
 `enable_orjson_parser`_:
-    (EXPERIMENTAL - Introduced in Cosmos 1.13.1): Enable the use of orjson for parsing dbt manifest files
+    (EXPERIMENTAL - Introduced in Cosmos 1.14.0): Enable the use of orjson for parsing dbt manifest files
     instead of the standard json library. orjson provides significantly faster JSON parsing performance,
     which can reduce DAG parsing time for large dbt projects. Requires installing orjson via
     ``astronomer-cosmos[orjson]``.

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -261,6 +261,21 @@ This page lists all available Airflow configurations that affect ``astronomer-co
         :start-after: [START cosmos_init_imports]
         :end-before: [END cosmos_init_imports]
 
+.. _enable_orjson_parser:
+
+`enable_orjson_parser`_:
+    (EXPERIMENTAL - Introduced in Cosmos 1.13.1): Enable the use of orjson for parsing dbt manifest files
+    instead of the standard json library. orjson provides significantly faster JSON parsing performance,
+    which can reduce DAG parsing time for large dbt projects. Requires installing orjson via
+    ``astronomer-cosmos[orjson]``.
+
+    - Default: ``False``
+    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_ORJSON_PARSER``
+
+    .. note::
+        This is an experimental feature. If enabled without installing orjson, Cosmos will raise an error
+        with installation instructions.
+
 
 [openlineage]
 ~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dbt-sqlserver = ["dbt-sqlserver"]
 dbt-teradata = ["dbt-teradata"]
 dbt-vertica = ["dbt-vertica<=1.5.4"]
 openlineage = ["openlineage-integration-common!=1.15.0", "openlineage-airflow"]
+orjson = ["orjson==3.11.7"]
 amazon = [
     "apache-airflow-providers-amazon[s3fs]>=3.0.0",
 ]

--- a/tests/dbt/test_orjson_parser.py
+++ b/tests/dbt/test_orjson_parser.py
@@ -1,0 +1,120 @@
+"""
+Tests for the experimental orjson parser feature.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cosmos import settings
+from cosmos.config import ExecutionConfig, ProjectConfig, RenderConfig
+from cosmos.dbt.graph import CosmosLoadDbtException, DbtGraph
+
+SAMPLE_MANIFEST = Path(__file__).parent.parent / "sample/manifest.json"
+
+
+def _is_orjson_available() -> bool:
+    """Check if orjson is available for testing."""
+    try:
+        import orjson
+        return True
+    except ImportError:
+        return False
+
+
+class TestOrjsonParserSettings:
+    """Tests for orjson parser settings."""
+
+    def test_orjson_disabled_by_default(self):
+        """Verify orjson parser is disabled by default."""
+        assert settings.enable_orjson_parser is False
+
+    @patch.object(settings, "enable_orjson_parser", True)
+    def test_orjson_setting_can_be_overridden(self):
+        """Verify setting can be overridden via environment variable."""
+        assert settings.enable_orjson_parser is True
+
+
+class TestOrjsonParserWithoutOrjson:
+    """Tests for behavior when orjson is not installed."""
+
+    @patch.object(settings, "enable_orjson_parser", True)
+    @patch("cosmos.dbt.graph.orjson", None)
+    def test_raises_error_when_orjson_not_installed(self):
+        """Verify clear error is raised when orjson is enabled but not installed."""
+        project_config = ProjectConfig(manifest_path=SAMPLE_MANIFEST, project_name="jaffle_shop")
+        execution_config = ExecutionConfig(dbt_project_path=Path(__file__).parent.parent / "sample")
+        render_config = RenderConfig()
+
+        dbt_graph = DbtGraph(
+            project=project_config,
+            execution_config=execution_config,
+            render_config=render_config,
+        )
+
+        with pytest.raises(CosmosLoadDbtException) as exc_info:
+            dbt_graph.load_from_dbt_manifest()
+
+        assert "orjson" in str(exc_info.value).lower()
+        assert "not installed" in str(exc_info.value).lower()
+        assert "astronomer-cosmos[orjson]" in str(exc_info.value)
+
+
+@pytest.mark.skipif(
+    not _is_orjson_available(),
+    reason="orjson not installed - install with: pip install orjson",
+)
+class TestOrjsonParserWithOrjson:
+    """Tests that require orjson to be installed."""
+
+    @patch.object(settings, "enable_orjson_parser", False)
+    def test_uses_standard_json_when_disabled(self):
+        """Verify standard json is used when orjson is disabled."""
+        project_config = ProjectConfig(manifest_path=SAMPLE_MANIFEST, project_name="jaffle_shop")
+        execution_config = ExecutionConfig(dbt_project_path=Path(__file__).parent.parent / "sample")
+        render_config = RenderConfig()
+
+        dbt_graph = DbtGraph(
+            project=project_config,
+            execution_config=execution_config,
+            render_config=render_config,
+        )
+        dbt_graph.load_from_dbt_manifest()
+
+        assert len(dbt_graph.nodes) > 0
+
+    @patch.object(settings, "enable_orjson_parser", True)
+    def test_orjson_produces_same_results_as_standard(self):
+        """Verify orjson produces identical results to standard json parser."""
+        project_config = ProjectConfig(manifest_path=SAMPLE_MANIFEST, project_name="jaffle_shop")
+        execution_config = ExecutionConfig(dbt_project_path=Path(__file__).parent.parent / "sample")
+        render_config = RenderConfig()
+
+        # Load with standard json
+        dbt_graph_standard = DbtGraph(
+            project=project_config,
+            execution_config=execution_config,
+            render_config=render_config,
+        )
+        with patch.object(settings, "enable_orjson_parser", False):
+            dbt_graph_standard.load_from_dbt_manifest()
+
+        # Load with orjson
+        dbt_graph_orjson = DbtGraph(
+            project=project_config,
+            execution_config=execution_config,
+            render_config=render_config,
+        )
+        dbt_graph_orjson.load_from_dbt_manifest()
+
+        # Compare results
+        assert dbt_graph_standard.nodes.keys() == dbt_graph_orjson.nodes.keys()
+        
+        for node_id in dbt_graph_standard.nodes:
+            standard_node = dbt_graph_standard.nodes[node_id]
+            orjson_node = dbt_graph_orjson.nodes[node_id]
+            
+            assert standard_node.unique_id == orjson_node.unique_id
+            assert standard_node.resource_type == orjson_node.resource_type
+            assert standard_node.depends_on == orjson_node.depends_on


### PR DESCRIPTION
This pull request introduces an experimental feature to enable faster JSON parsing of dbt manifest files using the `orjson` library, along with related configuration, error handling, and tests. The main changes include adding the optional `orjson` dependency, updating the configuration and documentation, modifying the manifest loading logic to use `orjson` if enabled, and adding comprehensive tests for this new feature.

**Experimental orjson parser support:**

* Added an experimental configuration option `enable_orjson_parser` to use `orjson` for parsing dbt manifest files, with a fallback to the standard `json` library if not enabled. This option is disabled by default and can be set via Airflow configuration or environment variable. (`cosmos/settings.py`, `docs/configuration/cosmos-conf.rst`) [[1]](diffhunk://#diff-2317d3342b8470278e95b3fcc555507acb062a595c518396ad5b94f1d3021e3eR92-R94) [[2]](diffhunk://#diff-f8b5ef1866b651723fe22ddc486850804cfe5369d3f5d05d2bedc78ba1ef9dfbR264-R278)
* Updated the manifest loading logic in `DbtGraph.load_from_dbt_manifest` to use `orjson` when the experimental parser is enabled, including clear error handling if `orjson` is not installed. (`cosmos/dbt/graph.py`) [[1]](diffhunk://#diff-06a246b81b5501335f001a4ce2e5492332cfff7896388024a9a2f839a8a27e6cR21-R26) [[2]](diffhunk://#diff-06a246b81b5501335f001a4ce2e5492332cfff7896388024a9a2f839a8a27e6cR1135-R1143)
* Added `orjson` as an optional dependency in `pyproject.toml` for users who wish to enable the experimental parser.

**Testing and validation:**

* Introduced a new test module `test_orjson_parser.py` to verify the new parser setting, error handling when `orjson` is missing, and to ensure `orjson` produces identical results to the standard parser. (`tests/dbt/test_orjson_parser.py`)